### PR TITLE
Marking validator data header function as inline

### DIFF
--- a/validator/ValidatePath.hpp
+++ b/validator/ValidatePath.hpp
@@ -27,7 +27,7 @@ SOFTWARE.
 
 namespace inx {
 
-std::unique_ptr<BresenhamRay>& ValidatePath_data()
+inline std::unique_ptr<BresenhamRay>& ValidatePath_data()
 {
     static std::unique_ptr<BresenhamRay> rayShooter;
     return rayShooter;


### PR DESCRIPTION
Minor bug fix, for including validator/ValidatePath.hpp multiple times will result in multiple definitions errors.